### PR TITLE
Fix coredump in Python when using "get_namespaces"

### DIFF
--- a/src/optional/python-bindings/gnucash_core.py
+++ b/src/optional/python-bindings/gnucash_core.py
@@ -335,7 +335,8 @@ class GncCommodityTable(GnuCashCoreClass):
     which includes most of the world's currencies.
     """
 
-    pass
+    def _get_namespaces_py(self):
+        return [ns.get_name() for ns in self.get_namespaces_list()]
 
 class GncCommodityNamespace(GnuCashCoreClass):
     pass
@@ -518,12 +519,12 @@ commoditytable_dict =   {
 methods_return_instance(GncCommodityTable, commoditytable_dict)
 
 methods_return_instance_lists(
-    GncCommodityTable, { 'get_namespaces': GncCommodityNamespace,
-                         'get_namespaces_list': GncCommodityNamespace,
+    GncCommodityTable, { 'get_namespaces_list': GncCommodityNamespace,
                          'get_commodities': GncCommodity,
                          'get_quotable_commodities': GncCommodity,
                          
                        } )
+setattr(GncCommodityTable, 'get_namespaces', getattr(GncCommodityTable, '_get_namespaces_py'))
 
 # GncCommodityNamespace
 GncCommodityNamespace.add_methods_with_prefix('gnc_commodity_namespace_')

--- a/src/optional/python-bindings/tests/runTests.py
+++ b/src/optional/python-bindings/tests/runTests.py
@@ -10,9 +10,10 @@ from test_account import TestAccount
 from test_split import TestSplit
 from test_transaction import TestTransaction
 from test_business import TestBusiness
+from test_commodity import TestCommodity, TestCommodityNamespace
 
 def test_main():
-    test_support.run_unittest(TestBook, TestAccount, TestSplit, TestTransaction, TestBusiness)
+    test_support.run_unittest(TestBook, TestAccount, TestSplit, TestTransaction, TestBusiness, TestCommodity, TestCommodityNamespace)
 
 if __name__ == '__main__':
     test_main()

--- a/src/optional/python-bindings/tests/test_commodity.py
+++ b/src/optional/python-bindings/tests/test_commodity.py
@@ -1,0 +1,32 @@
+from unittest import TestCase, main
+
+from gnucash import Session
+
+class CommoditySession( TestCase ):
+    def setUp(self):
+        self.ses = Session()
+        self.book = self.ses.get_book()
+        self.table = self.book.get_table()
+
+    def tearDown(self):
+        self.ses.end()
+
+class TestCommodity( CommoditySession ):
+    def test_iso_currency(self):
+        eur = self.table.lookup('CURRENCY', 'EUR')
+        self.assertIsNotNone(eur)
+
+class TestCommodityNamespace( CommoditySession ):
+    def test_namespaces(self):
+        print(self.table.__class__)
+        namespace_names = self.table.get_namespaces()
+        print(namespace_names)
+        self.assertEqual(namespace_names, ['AMEX', 'NYSE', 'NASDAQ', 'EUREX', 'FUND', 'template', 'CURRENCY'])
+
+    def test_namespaces_list(self):
+        namespaces = self.table.get_namespaces_list()
+        namespace_names = [ns.get_name() for ns in namespaces]
+        self.assertEqual(namespace_names, ['AMEX', 'NYSE', 'NASDAQ', 'EUREX', 'FUND', 'template', 'CURRENCY'])
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The Python API incorectly had GncCommodityTable.get_namespaces() defined
as a list of GncCommodityNamespace over the correct list of String. This
fixes the issue and adds a test for GncCommodityTable.get_namespaces()
and GncCommodityTable.get_namespaces_list().

Note: This is not a direct fix as I could not get SWIG to detect/convert
"GList *" to a "gchar *" to a Python str list.